### PR TITLE
feat: add integrated test for python greeter

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -36,3 +36,7 @@ run-server:
 
 run-server-docker:
 	docker run -it --rm -e PORT=8080 -p 50051:8080 greeter-server-python:latest
+
+test:
+	uv pip install -e .[dev]
+	uv run pytest

--- a/python/greeter/server.py
+++ b/python/greeter/server.py
@@ -30,15 +30,19 @@ class Greeter(pb2_grpc.GreeterServicer):
         return pb2.HelloReply(message=f"Hello {request.name}!")
 
 
-def serve():
+def serve(port: str = "50051"):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    port = os.environ.get("PORT", "50051")
     pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
     server_url = f"[::]:{port}"
     server.add_insecure_port(server_url)
     logger.info(f"gRPC server running at {server_url}")
     server.start()
+    return server
 
+
+def serve_forever():
+    port = os.environ.get("PORT", "50051")
+    server = serve(port)
     try:
         while True:
             time.sleep(_ONE_DAY_IN_SECONDS)
@@ -47,4 +51,4 @@ def serve():
 
 
 if __name__ == "__main__":
-    serve()
+    serve_forever()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,21 +2,16 @@
 name = "greeter"
 version = "0.1.2"
 description = ""
-authors = [
-    {name = "Ken Sato", email = "ksato9700@gmail.com"},
-]
+authors = [{ name = "Ken Sato", email = "ksato9700@gmail.com" }]
 requires-python = ">=3.13,<3.14"
-dependencies = [
-    "grpcio==1.71.0",
-    "protobuf>=5.29.4",
-    "click>=8.2.0",
-]
+dependencies = ["grpcio==1.71.0", "protobuf>=5.29.4", "click>=8.2.0"]
 
 [project.optional-dependencies]
 dev = [
     "black>=25.1.0",
     "flake8>=7.2.0",
     "grpcio-tools==1.71.0",
+    "pytest>=8.4.0",
 ]
 
 [build-system]

--- a/python/test_greeter.py
+++ b/python/test_greeter.py
@@ -1,0 +1,27 @@
+import time
+from multiprocessing import Process
+
+from greeter.server import serve
+from greeter_client import main
+
+
+def run_client():
+    main.callback(
+        server="localhost",
+        port=50051,
+        insecure=True,
+        cert_path=None,
+        name=("Joe", "Bill", "Donald"),
+    )
+
+
+def test_greeter():
+    server = serve()
+    try:
+        p = Process(target=run_client)
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+    finally:
+        server.stop(0)
+        time.sleep(1)


### PR DESCRIPTION
This PR adds an integrated test for the Python gRPC server and client. It also refactors the server to be programmatically startable and stoppable.